### PR TITLE
NES-8-added format to pre commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint
+npm run format && npm run lint

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"eslint-plugin-import": "^2.26.0",
 		"eslint-plugin-n": "^15.6.0",
 		"eslint-plugin-promise": "^6.1.1",
-		"husky": "^8.0.2"
+		"husky": "^8.0.2",
+		"is-ci": "^3.0.1"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This PR adds the command `npm run format` to the husky configuration before the pre-commit hook 